### PR TITLE
Added support for returning different response for different query parameters but same path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/shahariaazam/httpmama
 
 go 1.18
+
+require github.com/stretchr/testify v1.8.2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/httpmama.go
+++ b/httpmama.go
@@ -4,6 +4,7 @@ package httpmama
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 )
 
 // TestEndpoint store the endpoint specific configuration
@@ -11,6 +12,7 @@ type TestEndpoint struct {
 	Path           string
 	ResponseString string
 	ResponseHeader http.Header
+	QueryParams    url.Values
 }
 
 // ServerConfig store server configuration
@@ -22,21 +24,43 @@ type ServerConfig struct {
 func NewTestServer(config ServerConfig) *httptest.Server {
 	mux := http.NewServeMux()
 
-	for _, endpoint := range config.TestEndpoints {
-		path := endpoint.Path
-		responseString := endpoint.ResponseString
-		responseHeader := endpoint.ResponseHeader
+	// Use a map to store the response for each path and query parameter
+	responses := map[string]map[string]TestEndpoint{}
 
-		handler := func(w http.ResponseWriter, r *http.Request) {
-			for key, values := range responseHeader {
-				for _, value := range values {
-					w.Header().Add(key, value)
-				}
-			}
-			w.Write([]byte(responseString))
+	// Register a handler that looks up the response based on the path and query parameters
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		queryParams := r.URL.Query()
+
+		response, ok := responses[path][queryParams.Encode()]
+		if !ok {
+			// No response found for this path and query parameters, return a 404 response
+			http.NotFound(w, r)
+			return
 		}
 
-		mux.HandleFunc(path, handler)
+		for key, values := range response.ResponseHeader {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
+		w.Write([]byte(response.ResponseString))
+	}
+
+	// Register the handler for all paths
+	mux.HandleFunc("/", handler)
+
+	// Register each endpoint with its own set of query parameters
+	for _, endpoint := range config.TestEndpoints {
+		path := endpoint.Path
+
+		if responses[path] == nil {
+			// Create a new map for this path if it doesn't exist yet
+			responses[path] = map[string]TestEndpoint{}
+		}
+
+		// Store the response for this path and query parameters
+		responses[path][endpoint.QueryParams.Encode()] = endpoint
 	}
 
 	return httptest.NewServer(mux)

--- a/httpmama_test.go
+++ b/httpmama_test.go
@@ -1,11 +1,12 @@
 package httpmama
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateTestServer(t *testing.T) {


### PR DESCRIPTION
**Added**

- Added support for returning different response for different query parameters but same path for `NewTestServer()` function
- Added `	QueryParams    url.Values` for `TestEndpoint` type. Now you can define query parameters separately for each endpoint
- Added more tests with more use-cases